### PR TITLE
Dev 2.0.1

### DIFF
--- a/06_neural_networks/deep_learning_101/lecture_deeplearning_101.ipynb
+++ b/06_neural_networks/deep_learning_101/lecture_deeplearning_101.ipynb
@@ -658,7 +658,7 @@
    "source": [
     "#view as 0/1\n",
     "THRESHOLD = 0.5\n",
-    "(y_pred >= THRESHOLD).astype(np.int)"
+    "(y_pred >= THRESHOLD).astype('int')"
    ]
   },
   {

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - seaborn=0.11.2
   - statsmodels=0.11.1
   - pip:
-    - tensorflow==2.7.0
+    - tensorflow-cpu==2.7.0
     - pmdarima==1.6.0
     - scikit-learn==0.23.0
     - pystan==2.19.1.1


### PR DESCRIPTION
Patches:

- Conda env; switched to `tensorflow-cpu==2.7.0`
- Fixed deprecated code in deep learning 101 lecture.